### PR TITLE
Fix parse errors; add model docstring as table note

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-dbml
-version = 0.3.5
+version = 0.4.0
 description = Django extension aimed to generate DBML from all models
 long_description_content_type = text/markdown
 long_description = file: README.md
@@ -8,7 +8,7 @@ url = https://github.com/makecodesdev/django-dbml
 author = Michel Wilhelm
 author_email = michelwilhelm@gmail.com
 license = MIT
-install_requires = 
+install_requires =
     django>=2.0
 
 classifiers =


### PR DESCRIPTION
The current dbml command generates dbml files from stock django models that cannot be parsed dbdocs. This corrects the problems that are causing parse errors and adds one enhancement.

- escape quotes in field help text
- only add many to many table relationships once
- when a model has a docstring, include it as a note on the table