### PR TITLE
Optionally specify apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ pip install django-dbml
 $ python manage.py dbml
 ```
 
+To generate DBML for a subset of your models, specify one or more Django app 
+names or models by app_label or app_label.ModelName. Related tables will still 
+be included in the DBML.
+
 # Thanks
 
 The initial code was based on https://github.com/hamedsj/DbmlForDjango project

--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -1,6 +1,6 @@
 from django_dbml.utils import to_snake_case
 from django.apps import apps
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import models
 
 
@@ -8,9 +8,10 @@ class Command(BaseCommand):
     help = "Generate a DBML file based on Django models"
 
     def add_arguments(self, parser):
-        # Positional arguments
-        parser.add_argument('apps', nargs='*',
-                            help='Generate DBML for models in the specified apps')
+        parser.add_argument(
+            'args', metavar='app_label[.ModelName]', nargs='*',
+            help='Restricts dbml generation to the specified app_label or app_label.ModelName.',
+        )
 
     def get_field_notes(self, field):
         if len(field.keys()) == 1:
@@ -34,7 +35,35 @@ class Command(BaseCommand):
             return ""
         return "[{}]".format(", ".join(attributes))
 
-    def handle(self, *args, **kwargs):
+    def get_app_tables(self, app_labels):
+        # get the list of models to generate DBML for
+
+        # if no apps are specified, process all models
+        if not app_labels:
+            return apps.get_models()
+
+        # get specific models when app or app.model is specified
+        app_tables = []
+        for app in app_labels:
+            app_label_parts = app.split('.')
+            # first part is always the app label
+            app_label = app_label_parts[0]
+            # use the second part as model label if set
+            model_label = app_label_parts[1] if len(app_label_parts) > 1 else None
+            try:
+                app_config = apps.get_app_config(app_label)
+            except LookupError as e:
+                raise CommandError(str(e))
+
+            app_config = apps.get_app_config(app_label)
+            if model_label:
+                app_tables.append(app_config.get_model(model_label))
+            else:
+                app_tables.extend(app_config.get_models())
+
+        return app_tables
+
+    def handle(self, *app_labels, **kwargs):
         all_fields = {}
         allowed_types = ["ForeignKey", "ManyToManyField"]
         for field_type in models.__all__:
@@ -49,17 +78,7 @@ class Command(BaseCommand):
         )
 
         tables = {}
-
-        if kwargs['apps']:
-            app_tables = []
-            # if applications are specified, get models for those
-            # applications only
-            for app in kwargs['apps']:
-                subapp = apps.get_app_config(app)
-                app_tables.extend(subapp.get_models())
-        else:
-            # by default, get all models
-            app_tables = apps.get_models()
+        app_tables = self.get_app_tables(app_labels)
 
         for app_table in app_tables:
             table_name = app_table.__name__

--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -5,7 +5,12 @@ from django.db import models
 
 
 class Command(BaseCommand):
-    help = "The main DBML management file"
+    help = "Generate a DBML file based on Django models"
+
+    def add_arguments(self, parser):
+        # Positional arguments
+        parser.add_argument('apps', nargs='*',
+                            help='Generate DBML for models in the specified apps')
 
     def get_field_notes(self, field):
         if len(field.keys()) == 1:
@@ -44,7 +49,18 @@ class Command(BaseCommand):
         )
 
         tables = {}
-        app_tables = apps.get_models()
+
+        if kwargs['apps']:
+            app_tables = []
+            # if applications are specified, get models for those
+            # applications only
+            for app in kwargs['apps']:
+                subapp = apps.get_app_config(app)
+                app_tables.extend(subapp.get_models())
+        else:
+            # by default, get all models
+            app_tables = apps.get_models()
+
         for app_table in app_tables:
             table_name = app_table.__name__
             tables[table_name] = {"fields": {}, "relations": []}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-dbml
-version = 0.4.0
+version = 0.5.0
 description = Django extension aimed to generate DBML from all models
 long_description_content_type = text/markdown
 long_description = file: README.md


### PR DESCRIPTION
Added a command line option to specify app or app.Model that limits the tables used to generate the DBML.

Syntax for specifying apps or models is the same as that used by Django's dumpdata. 