### PR TITLE
Handle field types without `help_text` as string

### DIFF
--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -153,7 +153,7 @@ class Command(BaseCommand):
                     "type": all_fields.get(type(field).__name__),
                 }
 
-                if "help_text" in field_attributes:
+                if "help_text" in field_attributes and field.help_text:
                     help_text = field.help_text.replace('"', '\\"')
                     tables[table_name]["fields"][field.name]["note"] = help_text
 


### PR DESCRIPTION
I was seeing `AttributeError: 'NoneType' object has no attribute 'replace'` for the call
```py
help_text = field.help_text.replace('"', '\\"')
```
Evidently some field types can have `help_text` in `field_attributes`, but `field.help_text` is still `None` (rather than an empty string). This is true in particular for `django-taggit`'s `TaggableManager`, which was the source of the error – a model that defined a `tags` field using
```py
tags = TaggableManager(blank=True)
```
which seems like a pretty common use case.