### PR TITLE
Supporting ManyToMany / through models

### DIFF
--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -134,7 +134,7 @@ class Command(BaseCommand):
                                 "table_from": table_name_m2m,
                                 "table_from_field": field.m2m_reverse_name(),
                                 "table_to": field.related_model.__name__,
-                                "table_to_field": field.m2m_target_field_name(),
+                                "table_to_field": field.m2m_reverse_target_field_name(),
                             }
                         )
                         tables[table_name_m2m]["fields"][field.m2m_reverse_name()] = {


### PR DESCRIPTION
Consider the following example:

```
class AModel(Model):
    a_id = CharField(max_length=32, unique=True, primary_key=True)


class ABs(Model):
    a = ForeignKey("appname.AModel", on_delete=CASCADE)
    b = ForeignKey("appname.BModel", on_delete=CASCADE, null=True, default=None)


class BModel(Model):
    b_id = CharField(max_length=32, unique=True, primary_key=True)
    a_models = ManyToManyField(related_name="b_models", through="appname.ABs", to="appname.AModel")

```

Running `python manage.py dbml > out.dbml` and `dbdocs build ./out.dbml` leads to 

```
✖ Failed: You have syntax error in out.dbml line 612 column 6. Can't find field "b_id" in table "AModel"
```

The fix I suggest resolves this issue