### PR TITLE
Fix for crashing when function alias provided that has NoneType for `inspect.getmodule(value)`

### DIFF
--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -38,7 +38,10 @@ class Command(BaseCommand):
 
             if name == "default":
                 if callable(value):
-                    value = "{}.{}()".format(inspect.getmodule(value).__name__, value.__name__)
+                    if inspect.getmodule(value).__name__:
+                        value = "{}.{}()".format(inspect.getmodule(value).__name__, value.__name__)
+                    else:
+                        value = "{}()".format(value.__name__)
                 elif isinstance(value, str):
                     value = "\"{}\"".format(value)
                 attributes.append('default:`{}`'.format(value))

--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
 
             if name == "default":
                 if callable(value):
-                    if inspect.getmodule(value).__name__:
+                    if inspect.getmodule(value):
                         value = "{}.{}()".format(inspect.getmodule(value).__name__, value.__name__)
                     else:
                         value = "{}()".format(value.__name__)


### PR DESCRIPTION
Generation crashes when using a model with a property as such:

```
from datetime import date
from model_utils.models import TimeStampedModel

class MyModel(TimeStampedModel):
   some_date = models.DateField(default=date.today, verbose_name="someDate")

```
^ this will crash because `inspect.getmodule(value)` when `value = date.today` returns NoneType which has no `__name__`.