### PR TITLE
Support for Table Groups and Table Header Colors and DB Comments for Fields and Tables

### DIFF
--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+import hashlib
 import inspect
 
 from django_dbml.utils import to_snake_case
@@ -23,6 +25,16 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--color_by_app", action="store_true",
+        )
+        parser.add_argument(
+            "--add_project_name", action="store_const",
+            default="My Django Project",
+            help="add name for the project",
+        )
+        parser.add_argument(
+            "--add_project_notes", action="store_const",
+            default="A project with a database",
+            help="add notes to describe the project",
         )
 
     def get_field_notes(self, field):
@@ -96,6 +108,12 @@ class Command(BaseCommand):
         return model.__module__.split(".")[0]
     def handle(self, *app_labels, **kwargs):
         self.options = kwargs
+        project_name = self.options["add_project_name"]
+        project_notes = self.options["add_project_notes"]
+        print(f'Project "{project_name}" {{')
+        print(f"Note:  '''{project_notes}\nLast Updated At {datetime.now(timezone.utc).strftime('%m-%d-%Y %I:%M%p UTC')}'''")
+        print("}\n")
+
         all_fields = {}
         allowed_types = ["ForeignKey", "ManyToManyField"]
         for field_type in models.__all__:

--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -135,7 +135,7 @@ class Command(BaseCommand):
         for app_table in app_tables:
             tl_module_name = self.get_tl_module_name(app_table)
             if self.options["color_by_app"]:
-                table_color = "#{:06x}".format(hash(tl_module_name) & 0xffffff).upper()
+                table_color = f"#{hashlib.sha256(tl_module_name.encode()).hexdigest()[:6]}"
             else:
                 table_color = ""
             table_name = self.get_table_name(app_table)

--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
                 continue
 
             if name == "note":
-                attributes.append('note:"{}"'.format(value))
+                attributes.append("note:'''{}'''".format(value))
                 continue
 
             if name in ("null", "pk", "unique"):
@@ -215,7 +215,7 @@ class Command(BaseCommand):
                 }
 
                 if "db_comment" in field_attributes and field.db_comment:
-                    tables[table_name]["fields"][field.name]["note"] = field.db_comment
+                    tables[table_name]["fields"][field.name]["note"] = field.db_comment.replace('"', '\\"')
 
                 if "help_text" in field_attributes and field.help_text:
                     help_text = field.help_text.replace('"', '\\"')
@@ -237,7 +237,7 @@ class Command(BaseCommand):
                     tables[table_name]["fields"][field.name]["default"] = field.default
 
             if app_table._meta.db_table_comment:
-                tables[table_name]["note"] = app_table._meta.db_table_comment
+                tables[table_name]["note"] = app_table._meta.db_table_comment.replace('"', '\\"')
 
             if app_table.__doc__:
                 try:
@@ -246,8 +246,11 @@ class Command(BaseCommand):
                     tables[table_name]["note"] = f"{app_table.__doc__}"
 
         for table_name, table in tables.items():
-            table_color = table_colors_and_groups[table_name]["color"]
-            print("Table {} [headercolor: {}] {{".format(table_name, table_color))
+            if self.options["color_by_app"]:
+                table_color = table_colors_and_groups[table_name]["color"]
+                print("Table {} [headercolor: {}] {{".format(table_name, table_color))
+            else:
+                print("Table {} {{".format(table_name))
             for field_name, field in table["fields"].items():
                 print(
                     "  {} {} {}".format(

--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -47,7 +47,8 @@ class Command(BaseCommand):
                 continue
 
             if name == "note":
-                attributes.append("note:'''{}'''".format(value))
+                value_formatted = value.replace("'", '"')
+                attributes.append("note: '''\n{}\n'''".format(value_formatted))
                 continue
 
             if name in ("null", "pk", "unique"):

--- a/django_dbml/management/commands/dbml.py
+++ b/django_dbml/management/commands/dbml.py
@@ -214,9 +214,15 @@ class Command(BaseCommand):
                     "type": all_fields.get(type(field).__name__),
                 }
 
+                if "db_comment" in field_attributes and field.db_comment:
+                    tables[table_name]["fields"][field.name]["note"] = field.db_comment
+
                 if "help_text" in field_attributes and field.help_text:
                     help_text = field.help_text.replace('"', '\\"')
-                    tables[table_name]["fields"][field.name]["note"] = help_text
+                    try:
+                        tables[table_name]["fields"][field.name]["note"] += f"\n{help_text}"
+                    except KeyError:
+                        tables[table_name]["fields"][field.name]["note"] = f"{help_text}"
 
                 if "null" in field_attributes and field.null is True:
                     tables[table_name]["fields"][field.name]["null"] = True
@@ -230,8 +236,14 @@ class Command(BaseCommand):
                 if "default" in field_attributes and field.default != models.fields.NOT_PROVIDED:
                     tables[table_name]["fields"][field.name]["default"] = field.default
 
-                if app_table.__doc__:
-                    tables[table_name]["note"] = app_table.__doc__
+            if app_table._meta.db_table_comment:
+                tables[table_name]["note"] = app_table._meta.db_table_comment
+
+            if app_table.__doc__:
+                try:
+                    tables[table_name]["note"] += f"\n{app_table.__doc__}"
+                except KeyError:
+                    tables[table_name]["note"] = f"{app_table.__doc__}"
 
         for table_name, table in tables.items():
             table_color = table_colors_and_groups[table_name]["color"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-dbml
-version = 0.8.0
+version = 0.9.2
 description = Django extension aimed to generate DBML from all models
 long_description_content_type = text/markdown
 long_description = file: README.md


### PR DESCRIPTION
- Create [header colors](https://dbdiagram.io/docs/release-notes/2019-10-table-header-color) for tables in the same django_apps, this is useful for viewing on dbdiagram.io for organization
- Create [table groups](https://dbdiagram.io/docs/table-groups) for tables in the same djanog_apps, this is useful for organizing on dbdiagram.io
- Support [db comment and db table comments](https://docs.djangoproject.com/en/4.2/releases/4.2/#comments-on-columns-and-tables). This PR makes those comments show up as notes in the generated dbml.
- Adds project name and notes to the dbml via command line args