### PR TITLE
ci: update production release workflow to use version tags without 'v…

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,7 +3,7 @@ name: Publish 📦 to PyPI
 on:
   push:
     tags:
-      - "v*"
+      - "*.*.*"
 
 permissions:
   contents: read
@@ -27,7 +27,7 @@ jobs:
 
           git_tag = os.environ["GITHUB_REF_NAME"]
           version = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
-          expected_tag = f"v{version}"
+          expected_tag = version
           if git_tag != expected_tag:
               raise SystemExit(f"Tag {git_tag!r} does not match project version {expected_tag!r}")
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ The repository publishes from GitHub Actions using a gated release flow:
 - `CI` runs a package build check separately
 - publish workflows reuse `CI` before building release artifacts
 - release artifacts are built once, uploaded, and published from those exact artifacts
-- production publishing happens only from tags in the format `vX.Y.Z`
+- production publishing happens only from tags in the format `X.Y.Z`
 - the production workflow validates that the Git tag matches `project.version`
 - publishing uses PyPI Trusted Publishing, not long-lived API tokens
 - TestPyPI publishing is manual via `workflow_dispatch`
@@ -88,8 +88,8 @@ Recommended production release flow:
 make test
 make lint
 make build
-git tag v1.0.1
-git push origin v1.0.1
+git tag 1.1.2
+git push origin 1.1.2
 ```
 
 After the tag is pushed, the PyPI workflow publishes that version if CI passes and the tag matches the package version.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 This project follows a tag-driven release process for production publishing:
 
 - CI runs on pull requests and pushes
-- production publishing runs only from tags matching `vX.Y.Z`
+- production publishing runs only from tags matching `X.Y.Z`
 - the release workflow validates that the Git tag matches `project.version`
 - production and TestPyPI publishing use Trusted Publishing with GitHub OIDC
 - release artifacts are built in CI and published from those exact artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-dbml"
-version = "1.1.1"
+version = "1.1.2"
 description = "Django extension aimed to generate DBML from installed models."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "django-dbml"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
…' prefix and bump project version to 1.1.2