### PR TITLE
Fix descending index KeyError and missing FK columns in table definitions

### DIFF
--- a/django_dbml/core/builder.py
+++ b/django_dbml/core/builder.py
@@ -59,6 +59,8 @@ class SchemaBuilder:
                         table_to_field=field_name,
                     )
                 )
+                table.fields[field_name] = self.build_field_definition(project, table_name, field)
+                self.add_field_index(table, model, field, field_name)
                 continue
 
             if isinstance(field, models.fields.related.ForeignKey):
@@ -72,6 +74,8 @@ class SchemaBuilder:
                         table_to_field=field_name,
                     )
                 )
+                table.fields[field_name] = self.build_field_definition(project, table_name, field)
+                self.add_field_index(table, model, field, field_name)
                 continue
 
             if isinstance(field, models.fields.related.ManyToManyField):
@@ -220,7 +224,7 @@ class SchemaBuilder:
 
     def add_meta_indexes(self, table: TableDefinition, model: type[Model]) -> None:
         for index in model._meta.indexes:
-            column_names = [model._meta._forward_fields_map[field_name].column for field_name in index.fields]
+            column_names = [model._meta._forward_fields_map[field_name.lstrip("-")].column for field_name in index.fields]
             table.indexes.append(
                 IndexDefinition(
                     fields=column_names,


### PR DESCRIPTION
- Strip leading '-' from field names in add_meta_indexes before looking up in _forward_fields_map, fixing a KeyError when indexes use descending fields (e.g. fields=["-timestamp"]).
```
class AuditLog(models.Model):
    timestamp = models.DateTimeField(...)

    class Meta:
        indexes = [
            models.Index(fields=["-timestamp"]),  # crashes django-dbml
        ]
```


- Emit FK and OneToOneField columns into table.fields before continuing, fixing "ref error: column not found" in dbdiagram.io caused by ref lines referencing columns that were never declared in the table body. This caused "ref error: column not found" when importing the DBML into dbdiagram.io. Fixed by calling `build_field_definition` and `add_field_index` for these fields before the `continue`, matching the pattern used for regular fields.

```
class Reception(models.Model):
    supplier = models.ForeignKey(Supplier, ...)  # supplier_id never appears in table body

    # Generated DBML would have:
    # ref: purchasing.Reception.supplier_id > catalog.Supplier.id
    # ...but no "supplier_id" column in the Table block → dbdiagram.io ref error
```

I hope you won't mind me vibecoding this, I'm more a gopher than a pythonist.

Thanks for your software, saved me a lot of time :bow: 