### PR TITLE
Bump django dependency version from <6.0 to <7.0 

### DIFF
--- a/django_dbml/core/builder.py
+++ b/django_dbml/core/builder.py
@@ -59,6 +59,8 @@ class SchemaBuilder:
                         table_to_field=field_name,
                     )
                 )
+                table.fields[field_name] = self.build_field_definition(project, table_name, field)
+                self.add_field_index(table, model, field, field_name)
                 continue
 
             if isinstance(field, models.fields.related.ForeignKey):
@@ -72,6 +74,8 @@ class SchemaBuilder:
                         table_to_field=field_name,
                     )
                 )
+                table.fields[field_name] = self.build_field_definition(project, table_name, field)
+                self.add_field_index(table, model, field, field_name)
                 continue
 
             if isinstance(field, models.fields.related.ManyToManyField):
@@ -220,7 +224,7 @@ class SchemaBuilder:
 
     def add_meta_indexes(self, table: TableDefinition, model: type[Model]) -> None:
         for index in model._meta.indexes:
-            column_names = [model._meta._forward_fields_map[field_name].column for field_name in index.fields]
+            column_names = [model._meta._forward_fields_map[field_name.lstrip("-")].column for field_name in index.fields]
             table.indexes.append(
                 IndexDefinition(
                     fields=column_names,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
   { name = "Michel Wilhelm", email = "michelwilhelm@gmail.com" },
 ]
 dependencies = [
-  "django>=4.2,<6.0",
+  "django>=4.2,<7.0",
 ]
 keywords = ["django", "dbml", "schema"]
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -50,7 +50,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "django", specifier = ">=4.2,<6.0" }]
+requires-dist = [{ name = "django", specifier = ">=4.2,<7.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
As the title says, this PR bumps up the max version of django so this package can be used on version +6