### PR TITLE
Fix multiline Note rendering broken for dbdiagram.io parser

### DIFF
--- a/django_dbml/core/renderer.py
+++ b/django_dbml/core/renderer.py
@@ -56,7 +56,7 @@ class DbmlRenderer:
             blocks.append(f"Table {table_name} {{")
 
         if table.note:
-            blocks.append("  Note: '''\n{}'''\n".format(cleanup_docstring(table.note)))
+            blocks.append("  Note: '''\n{}\n'''\n".format(cleanup_docstring(table.note)))
 
         for field_name, field in table.fields.items():
             blocks.append(f"  {field_name} {field.type} {self.render_field_attributes(field)}".rstrip())
@@ -79,7 +79,7 @@ class DbmlRenderer:
         if field.note:
             note = field.note.replace("'", '"')
             if "\n" in note:
-                attributes.append(f"note: '''\n{note}'''")
+                attributes.append(f"note: '''\n{note}\n'''")
             else:
                 attributes.append(f"note: '''{note}'''")
 


### PR DESCRIPTION
The DBML renderer outputs table-level and field-level multiline notes with the closing ```'``` on the same line as the last content line.

```
  Note: '''
content
*table: public.foo*'''
```

The dbdiagram.io (DBML) parser expects the closing ```'``` to be on **its own line** for proper multiline string termination.

```
  Note: '''
content
*table: public.foo*
'''
```

Same fix applied to field-level `note: '''` multiline attributes (e.g. verbose_name + help_text + choices).

**Before** → dbdiagram.io import errors on any table with a note (M2M linking tables, or models with docstrings/comments).

**After** → clean import, all notes display correctly.